### PR TITLE
Rename liftoff-cli to liftoff-export-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 version: 2
 
 builds:
-  - binary: liftoff
+  - binary: liftoff-export
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,7 +20,7 @@ builds:
 archives:
   - formats:
       - zip
-    name_template: "liftoff_{{ .Os }}_{{ .Arch }}"
+    name_template: "liftoff-export_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-# liftoff-cli
+# liftoff-export-cli
 
 A command-line interface for the [Liftoff](https://getgymbros.com) fitness app.
 
 ## Install
 
-Download the latest release for your platform from the [releases page](https://github.com/DTTerastar/liftoff-cli/releases/latest), unzip it, and place the binary in `~/bin`.
+Download the latest release for your platform from the [releases page](https://github.com/DTTerastar/liftoff-export-cli/releases/latest), unzip it, and place the binary in `~/bin`.
 
 **macOS (Apple Silicon):**
 ```sh
-curl -Lo /tmp/liftoff.zip https://github.com/DTTerastar/liftoff-cli/releases/latest/download/liftoff_darwin_arm64.zip
-unzip -jo /tmp/liftoff.zip -d ~/bin && rm /tmp/liftoff.zip
-chmod +x ~/bin/liftoff
+curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_arm64.zip
+unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
+chmod +x ~/bin/liftoff-export
 ```
 
 **macOS (Intel):**
 ```sh
-curl -Lo /tmp/liftoff.zip https://github.com/DTTerastar/liftoff-cli/releases/latest/download/liftoff_darwin_amd64.zip
-unzip -jo /tmp/liftoff.zip -d ~/bin && rm /tmp/liftoff.zip
-chmod +x ~/bin/liftoff
+curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_amd64.zip
+unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
+chmod +x ~/bin/liftoff-export
 ```
 
 **Linux (amd64):**
 ```sh
-curl -Lo /tmp/liftoff.zip https://github.com/DTTerastar/liftoff-cli/releases/latest/download/liftoff_linux_amd64.zip
-unzip -jo /tmp/liftoff.zip -d ~/bin && rm /tmp/liftoff.zip
-chmod +x ~/bin/liftoff
+curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_linux_amd64.zip
+unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
+chmod +x ~/bin/liftoff-export
 ```
 
 Make sure `~/bin` is in your `PATH`. If not, add this to your `~/.zshrc` or `~/.bashrc`:
@@ -37,41 +37,41 @@ export PATH="$HOME/bin:$PATH"
 ### Auth
 
 ```sh
-liftoff auth login      # Log in to Liftoff
-liftoff auth logout     # Remove stored auth tokens
-liftoff auth refresh    # Manually refresh the access token
+liftoff-export auth login      # Log in to Liftoff
+liftoff-export auth logout     # Remove stored auth tokens
+liftoff-export auth refresh    # Manually refresh the access token
 ```
 
 ### Workouts
 
 ```sh
-liftoff workouts list                       # List workouts in fitdown format
-liftoff workouts list --json                # Output as JSON
-liftoff workouts list --since 30d           # Filter by relative date (30d, 4w, 6m, 1y)
-liftoff workouts list --since 2025-01-01    # Filter by absolute date
-liftoff workouts list --exercise bench      # Filter to matching exercises
-liftoff workouts show 2025-03-08            # Show workout(s) for a date
-liftoff workouts show today                 # Show today's workout
-liftoff workouts show yesterday             # Show yesterday's workout
+liftoff-export workouts list                       # List workouts in fitdown format
+liftoff-export workouts list --json                # Output as JSON
+liftoff-export workouts list --since 30d           # Filter by relative date (30d, 4w, 6m, 1y)
+liftoff-export workouts list --since 2025-01-01    # Filter by absolute date
+liftoff-export workouts list --exercise bench      # Filter to matching exercises
+liftoff-export workouts show 2025-03-08            # Show workout(s) for a date
+liftoff-export workouts show today                 # Show today's workout
+liftoff-export workouts show yesterday             # Show yesterday's workout
 ```
 
 ### Workout Stats
 
 ```sh
-liftoff workouts stats                      # Per-exercise summaries with monthly graphs
-liftoff workouts stats --detail             # Per-session breakdown
-liftoff workouts stats --exercise curl      # Filter to matching exercises
-liftoff workouts stats --since 6m           # Filter by date
-liftoff workouts stats --json               # Output as JSON
+liftoff-export workouts stats                      # Per-exercise summaries with monthly graphs
+liftoff-export workouts stats --detail             # Per-session breakdown
+liftoff-export workouts stats --exercise curl      # Filter to matching exercises
+liftoff-export workouts stats --since 6m           # Filter by date
+liftoff-export workouts stats --json               # Output as JSON
 ```
 
 ### Bodyweights
 
 ```sh
-liftoff bodyweights list                    # List recorded bodyweights
-liftoff bodyweights list --since 6m         # Filter by date
-liftoff bodyweights stats                   # Stats with monthly graph and trends
-liftoff bodyweights stats --since 2025-01-01
+liftoff-export bodyweights list                    # List recorded bodyweights
+liftoff-export bodyweights list --since 6m         # Filter by date
+liftoff-export bodyweights stats                   # Stats with monthly graph and trends
+liftoff-export bodyweights stats --since 2025-01-01
 ```
 
 ## Output Format

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dturner/liftoff-cli/internal/auth"
+	"github.com/dturner/liftoff-export-cli/internal/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +37,7 @@ var loginCmd = &cobra.Command{
 		if err := auth.Login(email, password); err != nil {
 			return err
 		}
-		fmt.Println("Logged in. Tokens saved to ~/.config/liftoff/auth.json")
+		fmt.Println("Logged in. Tokens saved to ~/.config/liftoff-export/auth.json")
 		return nil
 	},
 }

--- a/cmd/bodyweights.go
+++ b/cmd/bodyweights.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-cli/internal/client"
+	"github.com/dturner/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "liftoff",
+	Use:   "liftoff-export",
 	Short: "CLI for the Liftoff fitness app",
 }
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-cli/internal/client"
+	"github.com/dturner/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-cli/internal/client"
+	"github.com/dturner/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dturner/liftoff-cli
+module github.com/dturner/liftoff-export-cli
 
 go 1.21.3
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -26,14 +26,14 @@ type TokenStore struct {
 
 func configPath() string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "liftoff", "auth.json")
+	return filepath.Join(home, ".config", "liftoff-export", "auth.json")
 }
 
 // GetToken returns a valid access token, refreshing if needed.
 func GetToken() (string, error) {
 	store, err := load()
 	if err != nil {
-		return "", fmt.Errorf("not logged in — run: liftoff auth login")
+		return "", fmt.Errorf("not logged in — run: liftoff-export auth login")
 	}
 	if time.Now().After(store.ExpiresAt) {
 		store, err = Refresh(store.RefreshToken)

--- a/internal/client/trpc.go
+++ b/internal/client/trpc.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dturner/liftoff-cli/internal/auth"
+	"github.com/dturner/liftoff-export-cli/internal/auth"
 )
 
 // Base URL — versioned per Liftoff release. Update via: liftoff config set-url <url>

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/dturner/liftoff-cli/cmd"
+import "github.com/dturner/liftoff-export-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- Rename Go module from `github.com/dturner/liftoff-cli` to `github.com/dturner/liftoff-export-cli`
- Rename binary from `liftoff` to `liftoff-export` (goreleaser, cobra root command, release artifacts)
- Update config path from `~/.config/liftoff/` to `~/.config/liftoff-export/`
- Update all import paths, README URLs, and CLI usage examples

## Test plan
- [x] `go build` compiles successfully
- [x] `grep -r "liftoff-cli"` returns no results
- [x] Git remote points to new repo URL
- [ ] Run `liftoff-export auth login` to verify config path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)