### PR TITLE
Use HOMEBREW_TAP_TOKEN for goreleaser releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch goreleaser from `GITHUB_TOKEN` to `HOMEBREW_TAP_TOKEN` so it can push the Homebrew formula to `DTTerastar/homebrew-tap`

## Test plan
- [ ] Merge, tag a new release, and verify the formula appears in the homebrew-tap repo
- [ ] `brew tap DTTerastar/tap && brew install liftoff-export`

🤖 Generated with [Claude Code](https://claude.com/claude-code)