### PR TITLE
Fix release: use separate tokens for release and Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,5 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,7 @@ brews:
   - repository:
       owner: DTTerastar
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/DTTerastar/liftoff-export-cli
     description: CLI tool to export and analyze workout data from the Liftoff fitness app
     license: MIT


### PR DESCRIPTION
## Summary
- Restore `GITHUB_TOKEN` for the release itself (creating the draft on GitHub)
- Pass `HOMEBREW_TAP_TOKEN` as `HOMEBREW_TAP_GITHUB_TOKEN` env var, referenced in `.goreleaser.yml` via `repository.token`

The previous PR replaced `GITHUB_TOKEN` entirely, which broke release creation (403).

## Test plan
- [ ] Merge, delete v1.0.3 tag/release, re-tag, verify both release and formula are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)