### PR TITLE
Rename Homebrew formula to liftoff-export

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,8 @@ checksum:
   name_template: checksums.txt
 
 brews:
-  - repository:
+  - name: liftoff-export
+    repository:
       owner: DTTerastar
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add `name: liftoff-export` to goreleaser brews config so the formula matches the binary name

## Test plan
- [ ] Merge, re-release, then `brew install liftoff-export`

🤖 Generated with [Claude Code](https://claude.com/claude-code)