### PR TITLE
chore: move to quantcli org and migrate to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,15 +25,24 @@ archives:
 checksum:
   name_template: checksums.txt
 
-brews:
+homebrew_casks:
   - name: liftoff-export
     repository:
-      owner: DTTerastar
+      owner: quantcli
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: https://github.com/DTTerastar/liftoff-export-cli
+    directory: Casks
+    homepage: https://github.com/quantcli/liftoff-export-cli
     description: CLI tool to export and analyze workout data from the Liftoff fitness app
     license: MIT
+    url:
+      verified: github.com/quantcli/liftoff-export-cli
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/liftoff-export"]
+          end
 
 release:
   draft: true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Export and analyze your workout data from the [Liftoff](https://getgymbros.com) fitness app. A command-line tool to back up gym sessions, track bodyweight trends, and view exercise statistics — all from your terminal.
 
-[![Latest Release](https://img.shields.io/github/v/release/DTTerastar/liftoff-export-cli)](https://github.com/DTTerastar/liftoff-export-cli/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/quantcli/liftoff-export-cli)](https://github.com/quantcli/liftoff-export-cli/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/github/go-mod/go-version/DTTerastar/liftoff-export-cli)](go.mod)
+[![Go](https://img.shields.io/github/go-mod/go-version/quantcli/liftoff-export-cli)](go.mod)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
 
 ## Features
@@ -21,7 +21,7 @@ Export and analyze your workout data from the [Liftoff](https://getgymbros.com) 
 
 ```sh
 # Install with Homebrew
-brew tap DTTerastar/tap
+brew tap quantcli/tap
 brew install liftoff-export
 
 # Log in and list recent workouts
@@ -33,36 +33,36 @@ liftoff-export workouts list --since 7d
 
 **Homebrew (macOS / Linux):**
 ```sh
-brew tap DTTerastar/tap
+brew tap quantcli/tap
 brew install liftoff-export
 ```
 
-Or download a pre-built binary from the [releases page](https://github.com/DTTerastar/liftoff-export-cli/releases/latest):
+Or download a pre-built binary from the [releases page](https://github.com/quantcli/liftoff-export-cli/releases/latest):
 
 **macOS (Apple Silicon):**
 ```sh
-curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_arm64.zip
+curl -Lo /tmp/liftoff-export.zip https://github.com/quantcli/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_arm64.zip
 unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
 chmod +x ~/bin/liftoff-export
 ```
 
 **macOS (Intel):**
 ```sh
-curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_amd64.zip
+curl -Lo /tmp/liftoff-export.zip https://github.com/quantcli/liftoff-export-cli/releases/latest/download/liftoff-export_darwin_amd64.zip
 unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
 chmod +x ~/bin/liftoff-export
 ```
 
 **Linux (amd64):**
 ```sh
-curl -Lo /tmp/liftoff-export.zip https://github.com/DTTerastar/liftoff-export-cli/releases/latest/download/liftoff-export_linux_amd64.zip
+curl -Lo /tmp/liftoff-export.zip https://github.com/quantcli/liftoff-export-cli/releases/latest/download/liftoff-export_linux_amd64.zip
 unzip -jo /tmp/liftoff-export.zip -d ~/bin && rm /tmp/liftoff-export.zip
 chmod +x ~/bin/liftoff-export
 ```
 
 **Windows (amd64):**
 
-Download `liftoff-export_windows_amd64.zip` from the [releases page](https://github.com/DTTerastar/liftoff-export-cli/releases/latest), extract it, and add the directory to your PATH.
+Download `liftoff-export_windows_amd64.zip` from the [releases page](https://github.com/quantcli/liftoff-export-cli/releases/latest), extract it, and add the directory to your PATH.
 
 Make sure `~/bin` is in your `PATH`. If not, add this to your `~/.zshrc` or `~/.bashrc`:
 ```sh

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dturner/liftoff-export-cli/internal/auth"
+	"github.com/quantcli/liftoff-export-cli/internal/auth"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/bodyweights.go
+++ b/cmd/bodyweights.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-export-cli/internal/client"
+	"github.com/quantcli/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-export-cli/internal/client"
+	"github.com/quantcli/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dturner/liftoff-export-cli/internal/client"
+	"github.com/quantcli/liftoff-export-cli/internal/client"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dturner/liftoff-export-cli
+module github.com/quantcli/liftoff-export-cli
 
 go 1.21.3
 

--- a/internal/client/trpc.go
+++ b/internal/client/trpc.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dturner/liftoff-export-cli/internal/auth"
+	"github.com/quantcli/liftoff-export-cli/internal/auth"
 )
 
 // Base URL — versioned per Liftoff release. Update via: liftoff config set-url <url>

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/dturner/liftoff-export-cli/cmd"
+import "github.com/quantcli/liftoff-export-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- Update module path, Go imports, README links, and goreleaser homepage from `dturner`/`DTTerastar` to `quantcli` (follows the repo transfer to the quantcli org)
- Migrate `brews:` → `homebrew_casks:` (the `brews:` config was deprecated in GoReleaser v2.10)
- Add `url.verified` and a post-install `xattr -dr com.apple.quarantine` hook so the unsigned macOS binary isn't blocked by Gatekeeper

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] On next release, confirm goreleaser publishes a cask to `quantcli/homebrew-tap` without deprecation warnings
- [ ] `brew install quantcli/tap/liftoff-export` works end-to-end on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)