### PR TITLE
fix: resolve dates and bucket timestamps in local time

### DIFF
--- a/cmd/bodyweights.go
+++ b/cmd/bodyweights.go
@@ -105,6 +105,7 @@ func loadBodyweightEntries(sinceFlag string) ([]bodyweightEntry, error) {
 		if err != nil {
 			continue
 		}
+		date = date.Local()
 		if !since.IsZero() && date.Before(since) {
 			continue
 		}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -103,7 +103,7 @@ func buildSummaries(posts []Post) []ExerciseSummary {
 	for _, p := range posts {
 		bw, _ := strconv.ParseFloat(strings.TrimSpace(p.Bodyweight), 64)
 		t, _ := time.Parse(time.RFC3339Nano, p.StartedAt)
-		date := t.Format("2006-01-02")
+		date := t.Local().Format("2006-01-02")
 
 		for _, e := range p.ExerciseData {
 			ss := sessionStats(e, bw)

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -87,7 +87,7 @@ var listCmd = &cobra.Command{
 
 func parseSince(s string) (time.Time, error) {
 	// Try absolute date first
-	if t, err := time.Parse("2006-01-02", s); err == nil {
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
 		return t, nil
 	}
 	// Try relative: e.g. 30d, 4w, 6m, 1y
@@ -137,7 +137,7 @@ var showCmd = &cobra.Command{
 			if err != nil {
 				continue
 			}
-			if t.Format("2006-01-02") == target.Format("2006-01-02") {
+			if t.Local().Format("2006-01-02") == target.Format("2006-01-02") {
 				matched = append(matched, p)
 			}
 		}
@@ -162,7 +162,7 @@ func parseDate(s string) (time.Time, error) {
 	case "yesterday":
 		return now.AddDate(0, 0, -1), nil
 	}
-	if t, err := time.Parse("2006-01-02", s); err == nil {
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
 		return t, nil
 	}
 	return time.Time{}, fmt.Errorf("invalid date: %q (use YYYY-MM-DD, today, or yesterday)", s)
@@ -223,7 +223,7 @@ func printFitdown(posts []Post) error {
 		if err != nil {
 			fmt.Printf("Workout %s\n", post.StartedAt)
 		} else {
-			fmt.Printf("Workout %s\n", t.Format("January 2, 2006"))
+			fmt.Printf("Workout %s\n", t.Local().Format("January 2, 2006"))
 		}
 
 		if post.SessionNotes != "" {


### PR DESCRIPTION
## Summary

Two bug classes were mixing UTC and local time, producing off-by-one-day results for users not in UTC:

1. **Absolute date flags used UTC.** \`--since 2025-01-01\` and \`show 2025-03-08\` went through \`time.Parse(\"2006-01-02\", …)\`, which defaults to UTC. Relative flags (\`--since 7d\`, \`today\`, \`yesterday\`) already anchored to local, so the two forms of the same flag had different semantics.
2. **Day-bucketing used the API's zone.** \`StartedAt\` (RFC3339Nano from the server) was \`.Format(\"2006-01-02\")\`'d without converting to local first. A workout logged at 11pm local (≈4am UTC next day) bucketed under the wrong date in stats, monthly bodyweight averages, and \`workouts show <date>\` comparisons.

Fix is mechanical:

- \`cmd/workouts.go\`: \`ParseInLocation(\"2006-01-02\", s, time.Local)\` in both \`parseSince\` and \`parseDate\`; \`.Local()\` on the timestamp before comparing in \`show\` and before formatting the fitdown header.
- \`cmd/stats.go\`: \`.Local()\` on the timestamp before formatting the per-session date key.
- \`cmd/bodyweights.go\`: normalize \`date = date.Local()\` once on ingest; every downstream format (list, monthly key, stats display) inherits local zone.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\` pass
- [x] \`workouts show today\` shows today's workout (was failing after 8pm EDT before, because \"today\" resolved to local Apr 21 but workouts logged earlier today had their RFC3339 timestamps formatted in UTC → Apr 22, mismatch)
- [x] \`workouts list --since 3d\` and \`workouts list --since 2026-04-20\` now return consistent data
- [ ] Reviewer: confirm your stats monthly graph doesn't shift workouts across month boundaries near midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)