### PR TITLE
fix(auth): bump API host to v2-12-3 and add LIFTOFF_API_BASE override

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,19 +4,57 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
 const (
-	apiBase          = "https://v2-12-2.api.getgymbros.com"
+	defaultAPIBase   = "https://v2-12-3.api.getgymbros.com"
 	refreshProcedure = "user.refreshToken"
 	userAgent        = "Liftoff/528 CFNetwork/3860.400.51 Darwin/25.3.0"
 )
+
+const apiBaseEnvVar = "LIFTOFF_API_BASE"
+
+var (
+	resolveOnce sync.Once
+	resolved    string
+)
+
+// ResolveAPIBase returns the env override LIFTOFF_API_BASE if set, else the
+// compiled-in default. Liftoff mints version-pinned hosts (e.g. v2-13-0) and
+// retires older ones; the env var lets users dodge a deprecation without
+// waiting for a new release. Logged once when an override is in effect so
+// users can tell which endpoint is active when something breaks.
+func ResolveAPIBase() string {
+	resolveOnce.Do(func() {
+		if v := strings.TrimSpace(os.Getenv(apiBaseEnvVar)); v != "" {
+			resolved = strings.TrimRight(v, "/")
+			fmt.Fprintf(os.Stderr, "liftoff-export: using %s=%s\n", apiBaseEnvVar, resolved)
+		} else {
+			resolved = defaultAPIBase
+		}
+	})
+	return resolved
+}
+
+// deprecatedMarker is the substring the Liftoff backend returns when the
+// version-pinned host this binary targets has been retired.
+const deprecatedMarker = "server is deprecated"
+
+func DeprecatedError(action string) error {
+	return fmt.Errorf("%s: Liftoff retired the API version this binary targets (%s). "+
+		"Workarounds: (a) update to a newer liftoff-export release, or "+
+		"(b) set %s=https://vX-Y-Z.api.getgymbros.com to point at a current version. "+
+		"The Liftoff iOS/Android app shows its version under Settings → About; matching that is usually safe.",
+		action, ResolveAPIBase(), apiBaseEnvVar)
+}
 
 type TokenStore struct {
 	AccessToken  string    `json:"access_token"`
@@ -51,7 +89,7 @@ func Refresh(refreshToken string) (*TokenStore, error) {
 		"0": map[string]any{"json": refreshToken},
 	})
 	reqURL := fmt.Sprintf("%s/api/trpc/%s?batch=1&input=%s",
-		apiBase, refreshProcedure, url.QueryEscape(string(input)))
+		ResolveAPIBase(), refreshProcedure, url.QueryEscape(string(input)))
 
 	req, _ := http.NewRequest("GET", reqURL, nil)
 	req.Header.Set("Accept", "*/*")
@@ -62,6 +100,14 @@ func Refresh(refreshToken string) (*TokenStore, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(strings.ToLower(string(body)), deprecatedMarker) {
+		return nil, DeprecatedError("token refresh")
+	}
 
 	var batch []struct {
 		Result *struct {
@@ -76,8 +122,8 @@ func Refresh(refreshToken string) (*TokenStore, error) {
 			JSON struct{ Message string `json:"message"` } `json:"json"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
-		return nil, err
+	if err := json.Unmarshal(body, &batch); err != nil {
+		return nil, fmt.Errorf("parse tRPC response: %w\nbody: %s", err, string(body))
 	}
 	if len(batch) == 0 || batch[0].Error != nil {
 		msg := "unknown error"
@@ -117,7 +163,7 @@ func Login(email, password string) error {
 			},
 		},
 	})
-	reqURL := fmt.Sprintf("%s/api/trpc/user.signIn?batch=1", apiBase)
+	reqURL := fmt.Sprintf("%s/api/trpc/user.signIn?batch=1", ResolveAPIBase())
 	req, _ := http.NewRequest("POST", reqURL, bytes.NewReader(input))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "*/*")
@@ -128,6 +174,14 @@ func Login(email, password string) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(strings.ToLower(string(body)), deprecatedMarker) {
+		return DeprecatedError("login")
+	}
 
 	var batch []struct {
 		Result *struct {
@@ -143,8 +197,8 @@ func Login(email, password string) error {
 			JSON struct{ Message string `json:"message"` } `json:"json"`
 		} `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
-		return err
+	if err := json.Unmarshal(body, &batch); err != nil {
+		return fmt.Errorf("parse tRPC response: %w\nbody: %s", err, string(body))
 	}
 	if len(batch) == 0 || batch[0].Result == nil {
 		msg := "unknown error"

--- a/internal/client/trpc.go
+++ b/internal/client/trpc.go
@@ -6,12 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/quantcli/liftoff-export-cli/internal/auth"
 )
-
-// Base URL — versioned per Liftoff release. Update via: liftoff config set-url <url>
-const BaseURL = "https://v2-12-2.api.getgymbros.com"
 
 // UserAgent matches the iOS app so the server accepts our requests.
 const UserAgent = "Liftoff/528 CFNetwork/3860.400.51 Darwin/25.3.0"
@@ -24,7 +22,7 @@ type Client struct {
 func New() *Client {
 	return &Client{
 		http:    &http.Client{},
-		baseURL: BaseURL,
+		baseURL: auth.ResolveAPIBase(),
 	}
 }
 
@@ -74,6 +72,10 @@ func (c *Client) Query(procedure string, input any, out any) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(strings.ToLower(string(body)), "server is deprecated") {
+		return auth.DeprecatedError(fmt.Sprintf("tRPC %s", procedure))
 	}
 
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
## Summary
- Liftoff retired the `v2-12-2` host with `"The server is deprecated."`, breaking every authenticated subcommand once the cached access token expires. Bumps the compiled-in default to `v2-12-3` (probed: v2-12-3 is the only live host right now — v2-13-0..2 also return deprecated; v2-14+ don't resolve).
- Adds a `LIFTOFF_API_BASE` env-var override so the next deprecation can be worked around without waiting on a release. Logged once to stderr when the override is in effect.
- Surfaces an actionable error when the backend returns the deprecation marker, from `auth refresh`, `auth login`, or any authenticated tRPC query — points users at the env-var workaround and notes that the Liftoff iOS/Android app shows its version under Settings → About.

## Why this design
- Env-var override + clear error beats automatic version probing/fallback in the CLI; probing would silently mask real breakage.
- `tokenURL`/path stays unchanged — only the host varies between Liftoff versions.
- Tokens are user-bound, not host-bound: existing `~/.config/liftoff-export/auth.json` survives the version bump (verified locally — `workouts list --since 7d` succeeded with the previous token against the new default).

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [x] `LIFTOFF_API_BASE=https://v2-12-2.api.getgymbros.com liftoff-export auth refresh` → emits override banner, then actionable deprecation error (not bare upstream text)
- [x] `liftoff-export auth refresh` (no override, default v2-12-3) → succeeds
- [x] `liftoff-export workouts list --since 7d` → returns real workouts via tRPC
- [ ] After release: re-run morning Liftoff digest end-to-end to confirm it feeds the coach again

## Followup (release)
After merge, cut `v1.0.6` so the goreleaser workflow rebuilds the five platform binaries + checksums. Hold for explicit go-ahead before tagging.