### PR TITLE
feat!: replace --json with --format markdown|json

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -15,7 +15,7 @@ var (
 	statsSinceFlag    string
 	statsUntilFlag    string
 	statsExerciseFlag string
-	statsJSONFlag     bool
+	statsFormatFlag   string
 	statsDetailFlag   bool
 )
 
@@ -43,6 +43,10 @@ var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Show per-exercise statistics across workouts",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := validateFormat(statsFormatFlag)
+		if err != nil {
+			return err
+		}
 		c := client.New()
 		var posts []Post
 		if err := c.Query("post.getMyPosts", nil, &posts); err != nil {
@@ -71,7 +75,7 @@ var statsCmd = &cobra.Command{
 		})
 
 		summaries := buildSummaries(posts)
-		if statsJSONFlag {
+		if format == "json" {
 			return printJSON(summaries)
 		}
 		if statsDetailFlag {
@@ -88,7 +92,7 @@ func init() {
 	statsCmd.Flags().StringVar(&statsSinceFlag, "since", "", "Filter workouts on or after date (today, yesterday, YYYY-MM-DD, or Nd/Nw/Nm/Ny)")
 	statsCmd.Flags().StringVar(&statsUntilFlag, "until", "", "Filter workouts through date, inclusive (today, yesterday, YYYY-MM-DD, or Nd/Nw/Nm/Ny)")
 	statsCmd.Flags().StringVar(&statsExerciseFlag, "exercise", "", "Filter to exercises matching this name (word-prefix match)")
-	statsCmd.Flags().BoolVar(&statsJSONFlag, "json", false, "Output as JSON")
+	statsCmd.Flags().StringVar(&statsFormatFlag, "format", "markdown", "Output format: markdown (default) or json")
 	statsCmd.Flags().BoolVar(&statsDetailFlag, "detail", false, "Show per-session breakdown")
 }
 

--- a/cmd/workouts.go
+++ b/cmd/workouts.go
@@ -47,7 +47,7 @@ type Post struct {
 	ExerciseData    []ExerciseData `json:"exerciseData"`
 }
 
-var listJSONFlag bool
+var listFormatFlag string
 var listSinceFlag string
 var listUntilFlag string
 var listExerciseFlag string
@@ -56,6 +56,10 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all your workouts",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := validateFormat(listFormatFlag)
+		if err != nil {
+			return err
+		}
 		c := client.New()
 		var posts []Post
 		// post.getMyPosts returns all the user's own workouts (Memories view)
@@ -74,11 +78,26 @@ var listCmd = &cobra.Command{
 		if listExerciseFlag != "" {
 			posts = filterExercises(posts, listExerciseFlag)
 		}
-		if listJSONFlag {
+		if format == "json" {
 			return printJSON(posts)
 		}
 		return printFitdown(posts)
 	},
+}
+
+// validateFormat checks --format against the quantcli shared output set
+// (CONTRACT §4) and normalizes it to a canonical value. Liftoff currently
+// supports markdown (the default; fitdown-style) and json. "md" is accepted
+// as an alias.
+func validateFormat(format string) (string, error) {
+	switch format {
+	case "", "markdown", "md":
+		return "markdown", nil
+	case "json":
+		return "json", nil
+	default:
+		return "", fmt.Errorf("unknown --format %q (use markdown or json)", format)
+	}
 }
 
 // parseDateValue parses --since / --until / show argument values.
@@ -159,13 +178,17 @@ func filterByWindow(posts []Post, since, until time.Time) []Post {
 	return out
 }
 
-var showJSONFlag bool
+var showFormatFlag string
 
 var showCmd = &cobra.Command{
 	Use:   "show <date>",
 	Short: "Show workout(s) for a given date (e.g. 2025-03-08, today, yesterday)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		format, err := validateFormat(showFormatFlag)
+		if err != nil {
+			return err
+		}
 		target, err := parseDateValue(args[0])
 		if err != nil {
 			return err
@@ -196,7 +219,7 @@ var showCmd = &cobra.Command{
 			return nil
 		}
 
-		if showJSONFlag {
+		if format == "json" {
 			return printJSON(matched)
 		}
 		return printFitdown(matched)
@@ -206,8 +229,10 @@ var showCmd = &cobra.Command{
 func init() {
 	workoutsCmd.AddCommand(listCmd)
 	workoutsCmd.AddCommand(showCmd)
-	showCmd.Flags().BoolVar(&showJSONFlag, "json", false, "Output as JSON")
-	listCmd.Flags().BoolVar(&listJSONFlag, "json", false, "Output as JSON instead of fitdown")
+	showCmd.Flags().StringVar(&showFormatFlag, "format", "markdown",
+		"Output format: markdown (default, fitdown-style) or json")
+	listCmd.Flags().StringVar(&listFormatFlag, "format", "markdown",
+		"Output format: markdown (default, fitdown-style) or json")
 	listCmd.Flags().StringVar(&listSinceFlag, "since", "", "Filter workouts on or after date (today, yesterday, YYYY-MM-DD, or Nd/Nw/Nm/Ny)")
 	listCmd.Flags().StringVar(&listUntilFlag, "until", "", "Filter workouts through date, inclusive (today, yesterday, YYYY-MM-DD, or Nd/Nw/Nm/Ny)")
 	listCmd.Flags().StringVar(&listExerciseFlag, "exercise", "", "Filter to exercises matching this name (word-prefix match)")


### PR DESCRIPTION
## Summary

Per [CONTRACT §4](https://github.com/quantcli/common/blob/main/CONTRACT.md#4-output-format), every quantcli CLI exposes a single \`--format\` flag rather than per-format boolean shortcuts. This brings liftoff in line with crono and withings.

\`\`\`
liftoff-export workouts list  --format json
liftoff-export workouts show  today --format json
liftoff-export workouts stats --format json
\`\`\`

## Breaking change

\`--json\` is removed on \`workouts list\`, \`workouts show\`, and \`workouts stats\`. Migration: \`--json\` → \`--format json\`. \`md\` is accepted as an alias for \`markdown\` for symmetry with the existing crono behavior.

\`\`\`
$ liftoff-export workouts list --json
Error: unknown flag: --json

$ liftoff-export workouts list --format yaml
Error: unknown --format \"yaml\" (use markdown or json)

$ liftoff-export workouts list --format json
[ { \"id\": \"…\", … } ]
\`\`\`

## CSV

Intentionally not in the format set here — there's no CSV writer in liftoff, and adding one is out of scope for a flag-name harmonization PR. The contract permits each CLI to expose only the formats it implements; what's required is the flag name.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\` pass
- [x] \`--format json\` returns JSON
- [x] \`--format markdown\` returns fitdown
- [x] Bad \`--format yaml\` errors with the supported set
- [x] \`--json\` rejected with cobra's standard \"unknown flag\" message

## Cross-repo status

- crono: \`--format md|json\` already + \`--json\` shortcut. Will get a tiny followup PR to accept \`markdown\` (today only \`md\`).
- withings: \`--format markdown|json|csv\` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)