### PR TITLE
ci: probe API host daily, not weekly

### DIFF
--- a/.github/workflows/api-host-probe.yml
+++ b/.github/workflows/api-host-probe.yml
@@ -2,7 +2,7 @@ name: Probe Liftoff API host rotation
 
 on:
   schedule:
-    - cron: '0 14 * * 1'   # Mondays 14:00 UTC (10am EDT / 9am EST)
+    - cron: '0 14 * * *'   # Daily 14:00 UTC (10am EDT / 9am EST)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Liftoff retires version-pinned hosts faster than weekly. The Monday-only schedule meant up to 7 days between rotation and the auto-bump PR landing — that's the gap the user just hit.

Bumping the cron from \`0 14 * * 1\` (Mondays) to \`0 14 * * *\` (every day). Same 14:00 UTC time slot.

\`\`\`diff
-    - cron: '0 14 * * 1'   # Mondays 14:00 UTC
+    - cron: '0 14 * * *'   # Daily 14:00 UTC
\`\`\`

## Cost

Probe job is ~30s × 7 extra runs/week = ~3.5 minutes/week additional CI. Trivially under the free tier.

## What this doesn't fix

Even with daily probes, there's still the merge-then-release-then-brew-upgrade chain after the probe opens its auto-bump PR. Worst-case end-to-end lag goes from \`up to 7 days + manual cycle\` to \`up to 1 day + manual cycle\`.

If you want to shorten the manual cycle further, options for follow-up PRs:
- Auto-merge the probe-generated PR when CI passes (probe already verifies the new host is live).
- Auto-cut a patch release on the auto-merge.
- Make the binary discover the live host at runtime instead of compiling it in (the most robust fix; needs a Liftoff-side discovery hook, which may not exist).

Out of scope for this PR — happy to follow up on whichever you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
