### PR TITLE
fix(auth): bump default API host to v2-12-5

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultAPIBase   = "https://v2-12-3.api.getgymbros.com"
+	defaultAPIBase   = "https://v2-12-5.api.getgymbros.com"
 	refreshProcedure = "user.refreshToken"
 	userAgent        = "Liftoff/528 CFNetwork/3860.400.51 Darwin/25.3.0"
 )


### PR DESCRIPTION
Automated probe found `https://v2-12-3.api.getgymbros.com` returns "server is deprecated"; `https://v2-12-5.api.getgymbros.com` is currently live.

Branch was pushed by `.github/workflows/api-host-probe.yml` run 25604075028 on 2026-05-09. The `gh pr create` step inside the workflow failed because the repo/org setting `Allow GitHub Actions to create and approve pull requests` is currently off — opening this PR manually so the bump isn't blocked on that.

Verify before merge:
```sh
LIFTOFF_API_BASE=https://v2-12-5.api.getgymbros.com liftoff-export auth refresh
```

After merge, cut a patch release so brew users pick up the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
