### PR TITLE
fix(auth): bump default API host to v2-13-10

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultAPIBase   = "https://v2-12-5.api.getgymbros.com"
+	defaultAPIBase   = "https://v2-13-10.api.getgymbros.com"
 	refreshProcedure = "user.refreshToken"
 	userAgent        = "Liftoff/528 CFNetwork/3860.400.51 Darwin/25.3.0"
 )


### PR DESCRIPTION
## Summary

The previous bump (#43) landed on \`v2-12-5\` because it didn't return the deprecation marker. Turns out v2-12-5 returns 500 \"database is unreachable\" for everything — not a working host, just one that fails differently.

Manual sweep, anchored on the current iOS app (**2.13.10**, released yesterday per the [App Store](https://apps.apple.com/us/app/liftoff-ranked-gym-workouts/id6448081563)):

| Host | Response to invalid-token probe |
|---|---|
| v2-13-{6,7,8,9,10} | \`Session not found\` — **healthy** |
| v2-13-{0,1,2,3,4,5} | \`server is deprecated\` |
| v2-12-{5,6} | \`database is unreachable\` (500 — broken, not deprecated) |
| v2-12-{3,4}, v2-13-{0..5} | deprecated |

\`v2-13-10\` verified against a real refresh:

\`\`\`sh
$ LIFTOFF_API_BASE=https://v2-13-10.api.getgymbros.com liftoff-export auth refresh
Token valid: eyJhbGciOiJIUzI1NiIs...
\`\`\`

## Probe followup

The probe needs to be taught the difference between \"live (healthy 4xx like 'Session not found')\", \"broken/transient (500)\", and \"deprecated (FORBIDDEN with deprecation string)\". Otherwise we just fall into the same trap on the next rotation. Filing as a separate PR after this one merges.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\` pass
- [x] \`auth refresh\` against \`v2-13-10\` returns a real token
- [ ] Reviewer: confirm \`v2-13-10\` matches what your iOS app shows under Settings → About

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
