### PR TITLE
ci: replace auto-assign with native gh CLI version

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,19 +1,19 @@
-name: Auto Assign
+name: Auto-assign PR
+
 on:
-  issues:
-    types: [opened]
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
 jobs:
-  run:
+  assign:
+    if: github.event.pull_request.assignees[0] == null
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
-    - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
-      with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: DTTerastar
-          numOfAssignee: 1
+      - name: Assign PR to DTTerastar
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR_URL" --add-assignee DTTerastar


### PR DESCRIPTION
## Summary

Replaces the pozil/auto-assign-issue action with a hand-rolled gh-CLI step. Differences vs. the previous workflow:

- **Trigger:** `pull_request_target` (opened, reopened, ready_for_review) instead of `pull_request` opened. The `_target` variant runs in the base repo's context, which is what's needed for the assignment to work on PRs from forks.
- **Skip if assignees[0] is already set** — don't clobber an existing manual assignment.
- **Drops auto-assignment of issues.** If you want issue auto-assignment back, that's a separate workflow keyed off `issues.opened`.

## Cross-repo

Same change to all five quantcli repos as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
