### PR TITLE
chore: bump go directive to 1.25.10 + tidy (clears stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/quantcli/liftoff-export-cli
 
-go 1.21.3
+go 1.25.10
+
+require github.com/spf13/cobra v1.10.2
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from **1.21.3** (long-EOL) to **1.25.10** (latest 1.25.x patch) and re-tidies the module.

## Why

`liftoff-export-cli` was the only QuantCLI export-cli still on 1.21.x. Go 1.21 reached end-of-life over a year ago, which means any new stdlib CVE published against the language version this binary ships under is permanently unfixed. Bringing it up to 1.25.10 matches what `crono-export-cli` and `withings-export-cli` are landing in parallel and unblocks adoption of the supply-chain security workflow from [`quantcli/common`](https://github.com/quantcli/common).

## What changed

```diff
 module github.com/quantcli/liftoff-export-cli

-go 1.21.3
+go 1.25.10
+
+require github.com/spf13/cobra v1.10.2

 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )
```

Two effects from `go mod tidy`:

1. `go` directive updated to 1.25.10.
2. `github.com/spf13/cobra` was incorrectly marked `// indirect` even though `./cmd/*.go` imports it. `tidy` correctly promotes it to a direct requirement. `mousetrap` and `pflag` stay indirect — they're transitive cobra deps.

No `go.sum` changes — none of the module versions moved.

## Validation

Locally on this branch with Go 1.25.10:

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — no test files (parity with previous state)
- `go mod tidy` — produces this exact diff and nothing else
- `govulncheck ./...` — **No vulnerabilities found**

## Scope

`go.mod` only. No source changes, no behaviour changes, no dep version bumps. `release.yml` already uses `go-version-file: go.mod` so goreleaser will pick up 1.25.10 on the next release without any workflow edit.

## Refs

- `QUA-13`
- Companion bump: [`crono-export-cli` PR #32](https://github.com/quantcli/crono-export-cli/pull/32)
- Precedent: [`withings-export-cli` PR #35](https://github.com/quantcli/withings-export-cli/pull/35) (same shape)