### PR TITLE
feat(compat): adopt quantcli/common/compat/formats as second consumer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: go vet + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test ./...
+
+  compat:
+    name: compat (CONTRACT machine-attestation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: resolve compat dependency
+        # The compat module lives at github.com/quantcli/common/compat
+        # under a subpath. `go mod tidy` materializes go.sum for it on
+        # first run; subsequent runs are cache-served.
+        run: go mod tidy
+      - name: build liftoff-export
+        run: go build -o /tmp/liftoff-export .
+      - name: run compat suite
+        env:
+          # Path the compat-tagged test reads from os.Getenv.
+          LIFTOFF_EXPORT_BIN: /tmp/liftoff-export
+        run: go test -tags=compat -run TestContractFormats ./...

--- a/compat_contract_test.go
+++ b/compat_contract_test.go
@@ -1,0 +1,63 @@
+//go:build compat
+
+// Compat-test entry point for liftoff-export-cli.
+//
+// This file is only compiled under the `compat` build tag, so it does
+// not affect the default `go test ./...` run. CI invokes it as
+// `go test -tags=compat ./...` after building the export binary and
+// exposing its path through LIFTOFF_EXPORT_BIN.
+//
+// The actual assertions live in github.com/quantcli/common/compat.
+// Drift between this CLI and CONTRACT.md surfaces as a failure here.
+package main_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/quantcli/common/compat"
+	"github.com/quantcli/common/compat/formats"
+)
+
+// liftoffFormatSubcommands is the §4 surface for liftoff — each
+// data-producing leaf owns its own --format flag under a two-level
+// cobra path (parent group + leaf). The compat Runner splits on
+// whitespace so cobra sees separate argv entries (added in
+// quantcli/common PR #12).
+//
+// `workouts show` is intentionally excluded: it requires a positional
+// <date> argument, so the parse-level subtests would fail on missing
+// args rather than the --format flag itself. The four leaves below
+// take --format with no required positional and exercise the §4
+// surface cleanly.
+var liftoffFormatSubcommands = []string{
+	"workouts list",
+	"workouts stats",
+	"bodyweights list",
+	"bodyweights stats",
+}
+
+func TestContractFormats(t *testing.T) {
+	bin := os.Getenv("LIFTOFF_EXPORT_BIN")
+	if bin == "" {
+		t.Skip("LIFTOFF_EXPORT_BIN not set; skipping compat suite")
+	}
+	// liftoff implements --format markdown (default) and --format json
+	// today; CSV is not yet wired. SupportedFormats: ["markdown","json"]
+	// skips CSVHasHeader with a named reason rather than failing it.
+	//
+	// SkipDataPath: true opts out of JSONIsArray / CSVHasHeader /
+	// DefaultIsMarkdown — liftoff's data path requires a stored OAuth
+	// token at ~/.config/liftoff-export/auth.json which the compat CI
+	// job does not provision, so a clean `--format json` run exits
+	// non-zero with "not logged in" before the JSON-array assertion
+	// could run. The parse-level subtests (HelpDocumentsFormatFlag,
+	// UnknownFormatFails, FlagValidationIsHermetic) still attest the
+	// §4 surface.
+	formats.RunContract(t, compat.Runner{
+		Binary:           bin,
+		Subcommands:      liftoffFormatSubcommands,
+		SupportedFormats: []string{"markdown", "json"},
+		SkipDataPath:     true,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/quantcli/liftoff-export-cli
 
 go 1.25.10
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/quantcli/common/compat v0.0.0-20260519113336-de9219e03369
+	github.com/spf13/cobra v1.10.2
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/quantcli/common/compat v0.0.0-20260519113336-de9219e03369 h1:Ph45Q92vEk4rpcR/NGH/j0oBM9pin2Dk8Rh+Q2mhj3k=
+github.com/quantcli/common/compat v0.0.0-20260519113336-de9219e03369/go.mod h1:VBC/zEphSZgCZS1rhWsR3A8EWYSbTkP/MwqWHL7266s=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=


### PR DESCRIPTION
## Summary

Onboards liftoff-export-cli as the second machine-attested consumer of `quantcli/common/compat`, mirroring the crono pattern. Closes the liftoff side of [QUA-16](/QUA/issues/QUA-16).

## What

- `compat_contract_test.go` (build tag `compat`) — runs `compat/formats.RunContract` against the built binary via `LIFTOFF_EXPORT_BIN`.
- `.github/workflows/ci.yml` — adds two jobs:
  - `go vet + test` (parity with crono's default job).
  - `compat (CONTRACT machine-attestation)` — builds the binary, runs `go mod tidy`, then `go test -tags=compat -run TestContractFormats ./...`.
- `go.mod` — pins `github.com/quantcli/common/compat v0.0.0-…-de9219e03369` (merged-main pseudo-version, post-QUA-15 + nested-subcommand + SkipDataPath).

## Surface

Subcommands targeted (the four `--format`-bearing leaves without a required positional):

- `workouts list`
- `workouts stats`
- `bodyweights list`
- `bodyweights stats`

`workouts show` is intentionally excluded because its required `<date>` positional would surface "missing arg" rather than format-flag failure in `UnknownFormatFails`.

## Runner config

- `SupportedFormats: [markdown, json]` — CSV is not yet wired, so `CSVHasHeader` skips with a named reason.
- `SkipDataPath: true` — liftoff's data path requires a stored OAuth token at `~/.config/liftoff-export/auth.json` which CI does not provision; the parse-level subtests (`HelpDocumentsFormatFlag`, `UnknownFormatFails`, `FlagValidationIsHermetic`) still attest §4.

## Local verification

```
$ go build -o /tmp/liftoff-export .
$ LIFTOFF_EXPORT_BIN=/tmp/liftoff-export go test -tags=compat -run TestContractFormats ./...
ok  github.com/quantcli/liftoff-export-cli  0.031s
```

All four subcommand groups: 3 parse-level subtests PASS, 3 data-path subtests SKIP (`SkipDataPath`).

## Test plan

- [ ] `go vet + test` CI job green.
- [ ] `compat (CONTRACT machine-attestation)` CI job green.
- [ ] Drift later (e.g. removing `--format` from a leaf) surfaces as a named subtest failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)